### PR TITLE
Add default image description for images that do not have a caption

### DIFF
--- a/importScripts/sql/transformations/ObjectsImagesExportView.sql
+++ b/importScripts/sql/transformations/ObjectsImagesExportView.sql
@@ -8,7 +8,7 @@ SELECT
         REPLACE(REPLACE(REPLACE(REPLACE(REPLACE(ImageFilePath, '\\', '/'), 'Y:/', ''), 'Y:', ''),
                         '//Foyer/c/Images Mosaic/', ''), '//Foyer/c/Images Mosaic/', ''),
         '//SERVER1/Images Mosaic/', ''), ImageFileName)), '') AS ImagePath,
-    NULLIF(TRIM(ImageDescription), '')                        AS ImageDescription,
+    IFNULL(NULLIF(TRIM(ImageDescription), ''), TRIM(o.ItemName))                        AS ImageDescription,
     NULLIF(TRIM(DisplayImage), '')                            AS DisplayImage,
     NULLIF(TRIM(DefaultImageIndicator), '')                   AS DefaultImageIndicator
 


### PR DESCRIPTION
Not having a label was resulting in the representation label not being added which lead to it skipping to the next record. This is because we're using an [`objectRepresentationSplitter` refinery with attributes set](https://github.com/rwahs/import-scripts/blob/master/importScripts/refineryParameters/ImagePath.ca_object_representations.objectRepresentationSplitter.json#L8-L10). Defaulting to the ItemName is sensible if redundant. This is better than not having the images imported.
